### PR TITLE
added in the clamp values for the squash and stretch node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ excons.cache
 
 
 cover/
+/.vs

--- a/src/squashStretch2.cpp
+++ b/src/squashStretch2.cpp
@@ -219,10 +219,16 @@ MStatus mgear_squashStretch2::compute(const MPlug& plug, MDataBlock& data)
     MVector scl = MVector(sx, sy, sz);
     scl = linearInterpolate(gscale, scl, in_blend);
 
+	double clamp_value = 0.0001;
+
+	double scl_x = std::max(scl.x, clamp_value);
+	double scl_y = std::max(scl.y, clamp_value);
+	double scl_z = std::max(scl.z, clamp_value);
+
 	// Output
-    MDataHandle h = data.outputValue( output );
-	h.set3Float( (float)scl.x, (float)scl.y, (float)scl.z );
-    data.setClean( plug );
+	MDataHandle h = data.outputValue(output);
+	h.set3Float((float)scl_x, (float)scl_y, (float)scl_z);
+	data.setClean(plug);
 
 	return MS::kSuccess;
 }


### PR DESCRIPTION
Hi guys, took a look at this issue and added in a clamp parameter for the output vector on the node.

In Maya, tested to see if the mesh still explodes and does not seem to anymore.

Here is a snippet of one of the plugs showing the clamp working

![image](https://user-images.githubusercontent.com/31500795/98811511-a545b480-2429-11eb-8783-d6cb57975d80.png)
