### PR TITLE
added scale and rotation multipliers

### DIFF
--- a/src/mgear_solvers.h
+++ b/src/mgear_solvers.h
@@ -643,6 +643,16 @@ public:
 	static MObject aDrivenParentInverseMatrix;
 	static MObject aDrivenRestMatrix;
 
+	static MObject aRotationMultiplier;
+	static MObject aRotationMultiplierX;
+	static MObject aRotationMultiplierY;
+	static MObject aRotationMultiplierZ;
+
+	static MObject aScaleMultiplier;
+	static MObject aScaleMultiplierX;
+	static MObject aScaleMultiplierY;
+	static MObject aScaleMultiplierZ;
+
 	// -----------------------------------------
 	// output attributes
 	// -----------------------------------------


### PR DESCRIPTION
Added both scale and rotation multipliers to the node.

![matrix_node_01](https://user-images.githubusercontent.com/31500795/100873375-d571f780-34ab-11eb-9a18-1f8e9e879555.png)
![matrix_node_02](https://user-images.githubusercontent.com/31500795/100873382-d86ce800-34ab-11eb-9d12-cbffc81c8523.png)

What is used to look like on the right hand side:
![matrix_node_04](https://user-images.githubusercontent.com/31500795/100873463-efabd580-34ab-11eb-9507-61afb4634596.png)

Showing the local rotation axis as proof the orientation is still correct with the scale and rotation negated:
![matrix_node_03](https://user-images.githubusercontent.com/31500795/100873531-0520ff80-34ac-11eb-992d-2254639fd4e3.png)
